### PR TITLE
chore: use latest SWR, improve types

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,8 @@
 module.exports = {
   preset: 'ts-jest',
   testRegex: '/test/.*\\.test\\.*',
-  "collectCoverage": false,
-  "collectCoverageFrom": [
-    "src/**/*.ts"
-  ],
-  "coveragePathIgnorePatterns": [
-    "./test"
-  ]
-};
+  collectCoverage: false,
+  collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: ['./test'],
+  testEnvironment: 'jsdom',
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ether-swr",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Ether-SWR is a React hook that fetches blockchain data, streamlines the chores to keep the internal state of Decentralized App (DApp) and optimize the RPC calls to an Ethereum node.",
   "main": "./dist/index.js",
   "module": "./esm/index.js",
@@ -51,32 +51,31 @@
     "@types/jest": "24.0.20",
     "@types/node": "11.12.0",
     "@types/react": "16.9.11",
-    "@typescript-eslint/eslint-plugin": "2.34.0",
-    "@typescript-eslint/parser": "2.34.0",
+    "@typescript-eslint/eslint-plugin": "4.28.3",
+    "@typescript-eslint/parser": "4.28.3",
+    "@vercel/ncc": "^0.28.6",
     "@web3-react/core": "6.1.1",
-    "@zeit/ncc": "0.20.5",
     "eslint": "^7.22.0",
     "eslint-config-prettier": "6.5.0",
     "eslint-plugin-react-hooks": "4.0.4",
-    "ethers": "5.0.32",
+    "ethers": "5.4.1",
     "husky": "2.4.1",
     "jest": "26.6.0",
-    "jest-environment-jsdom-sixteen": "1.0.3",
     "lint-staged": "8.2.1",
     "prettier": "1.18.2",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-test-renderer": "^17.0.0",
-    "serve": "11.3.1",
+    "serve": "12.0.0",
     "standard-version": "9.1.0",
-    "swr": "^0.4.0",
+    "swr": "^0.5.6",
     "ts-jest": "^26.5.3",
-    "typescript": "3.9.3"
+    "typescript": "4.3.5"
   },
   "peerDependencies": {
     "ethers": "*",
     "react": "*",
     "react-dom": "*",
-    "swr": "*"
+    "swr": "^0.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
     "ethers": "*",
     "react": "*",
     "react-dom": "*",
-    "swr": "^0.5.6"
+    "swr": "*"
   }
 }

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,5 +1,5 @@
 export class ABIError extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message)
     // Set the prototype explicitly.
     Object.setPrototypeOf(this, ABIError.prototype)
@@ -7,7 +7,7 @@ export class ABIError extends Error {
 }
 
 export class ABINotFound extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message)
     // Set the prototype explicitly.
     Object.setPrototypeOf(this, ABINotFound.prototype)

--- a/src/ether-js-fetcher.ts
+++ b/src/ether-js-fetcher.ts
@@ -9,7 +9,7 @@ export const etherJsFetcher = (
   // JsonRpcSigner from useWeb3React
   signer: Wallet | JsonRpcSigner,
   ABIs?: Map<string, any>
-) => (...args) => {
+) => (...args: any[]) => {
   let parsed
   try {
     parsed = JSON.parse(args[0])

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ConfigInterface } from 'swr'
+import { SWRConfiguration } from 'swr'
 import { Wallet } from 'ethers'
 import { Listener, Provider } from '@ethersproject/abstract-provider'
 import { Signer } from '@ethersproject/abstract-signer'
@@ -14,7 +14,7 @@ export type Web3Provider = {
 }
 
 export interface EthSWRConfigInterface<Data = any, Error = any>
-  extends ConfigInterface<Data, Error> {
+  extends SWRConfiguration<Data, Error> {
   ABIs?: Map<string, any>
   signer?: Wallet | JsonRpcSigner // e.g. EtherJs wallet
   provider?: Provider | Web3Provider | any // pass only this e.g (useWeb3React) which has a provider with signer. FallbackProvider or Alchemy or Infura etc don't have the getSigner

--- a/src/useEtherSWR.ts
+++ b/src/useEtherSWR.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react'
 import useSWR, { cache, mutate } from 'swr'
-import { responseInterface } from 'swr'
+import { SWRResponse } from 'swr'
 import { isAddress } from '@ethersproject/address'
 import { EthSWRConfigInterface } from './types'
 import EthSWRConfigContext from './eth-swr-config'
@@ -22,19 +22,19 @@ const getSigner = (config: EthSWRConfigInterface) => {
 
 function useEtherSWR<Data = any, Error = any>(
   key: ethKeyInterface | ethKeysInterface | etherKeyFuncInterface
-): responseInterface<Data, Error>
+): SWRResponse<Data, Error>
 function useEtherSWR<Data = any, Error = any>(
   key: ethKeyInterface | ethKeysInterface | etherKeyFuncInterface,
   config?: EthSWRConfigInterface<Data, Error>
-): responseInterface<Data, Error>
+): SWRResponse<Data, Error>
 function useEtherSWR<Data = any, Error = any>(
   key: ethKeyInterface | ethKeysInterface | etherKeyFuncInterface,
   fetcher?: any, //fetcherFn<Data>,
   config?: EthSWRConfigInterface<Data, Error>
-): responseInterface<Data, Error>
+): SWRResponse<Data, Error>
 function useEtherSWR<Data = any, Error = any>(
-  ...args
-): responseInterface<Data, Error> {
+  ...args: any[]
+): SWRResponse<Data, Error> {
   let _key: ethKeyInterface
   let fn: any //fetcherFn<Data> | undefined
   let config: EthSWRConfigInterface<Data, Error> = { subscribe: [] }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,11 @@
-import { Contract } from 'ethers'
+import { Contract, ContractInterface } from 'ethers'
 
 export const contracts = new Map<string, Contract>()
-export function getContract(address, abi, signer) {
+export function getContract(
+  address: string,
+  abi: ContractInterface,
+  signer: any
+): Contract {
   let contract = contracts.get(address)
   if (contract) {
     return contract


### PR DESCRIPTION
This PR:

- updates SWR and Ethers.js to comply to the latest libraries types (some deprecated interfaces in SWR were replaced in this PR)
- types are improved, thanks to ESLint + TS plugin