### PR TITLE
Add "exports" field to support Node.js ESM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "engines": {
     "node": ">=10"
   },
+  "exports": {
+    "import": "./esm/index.js",
+    "require": "./dist/index.js"
+  },
   "react-native": "./esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Hello again, I'm in process of writing [next-eth](https://github.com/talentlessguy/next-eth), an Ethereum library for Next.js

It's a well-known problem that Next.js doesn't play with ESM well, but in recent version it [got fixed](https://github.com/vercel/next.js/pull/27069). You can try it out with Next.js 11.0.2-canary.14 and use this config:

```js
module.exports = {
  experimental: {
    esmExternals: 'loose'
  }
}
```

So there's a problem. My library depends on ether-swr. Next.js treats it as a CommonJS module because it has no "exports" field in package.json. And this results in this error:

```
SyntaxError: Named export 'etherJsFetcher' not found. The requested module 'ether-swr' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'ether-swr';
const { etherJsFetcher } = pkg;
```

the solution is to make this package **mixed** - e.g. have an `"exports"` declaration that points to CJS and ESM versions. Note that it will still work the same for old and new versions of Next.js

For more information, see this:

- [Packages exports](https://nodejs.org/api/packages.html#packages_exports)